### PR TITLE
Toggle template correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # fritzapi
 [![NPM Version](https://img.shields.io/npm/v/fritzapi.svg)](https://www.npmjs.com/package/fritzapi)
+[![NPM Downloads](https://img.shields.io/npm/dt/fritzapi.svg)](https://www.npmjs.com/package/fritzapi)
 [![Build status](https://travis-ci.org/andig/fritzapi.svg?branch=master)](https://travis-ci.org/andig/fritzapi)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=HWZTN5AU8LSUC)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Home automation node API for Fritz!Box, Fritz!DECT and FRITZ!Powerline devices.
 - Get device `getDevice` >Fritz!OS 6.10
 - Get temperature `getTemperature` - polyfill
 - Get presence `getPresence` - polyfill
+- Get template list as XML `getTemplateListInfos` >Fritz!OS 7.0
+- Get template list `getTemplateList` >Fritz!OS 7.0
+- Get template list `applyTemplate` >Fritz!OS 7.0
 
 **Note**
 
@@ -41,6 +44,7 @@ In general, use of `getDeviceListInfos` is discouraged as the equivalent `getDev
 - Get energy `getSwitchEnergy`
 - Get presence status `getSwitchPresence`
 - Get name `getSwitchName`
+- Get basic device stats as XML `getBasicDeviceStats` >Fritz!OS 7.0
 
 For controlling AVM Fritz!DECT 200 devices the actuator identification number (AIN) is needed. The AIN can be obtained using `getSwitchList` which returns a list of AINs or the more general `getDeviceList` function which returns a verbose device list structure as JSON.
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ Fritz.prototype = {
     getDeviceListInfo: function() {
         return this.call(module.exports.getDeviceListInfo);
     },
-    
+
     getDeviceListInfos: function() {
         return this.call(module.exports.getDeviceListInfos);
     },

--- a/index.js
+++ b/index.js
@@ -99,13 +99,18 @@ Fritz.prototype = {
     getTemplateListInfos : function() {
         return this.call(module.exports.getTemplateListInfos );
     },
-
-    setTemplate: function(ain) {
-        return this.call(module.exports.setTemplate, ain);
+    applyTemplate: function(ain) {
+        return this.call(module.exports.applyTemplate, ain);
     },
     
-    getDeviceListInfos: function() {
-        return this.call(module.exports.getDeviceListInfos);
+    //new functions related to templates in version 7
+    getTemplateListInfos : function() {
+        return this.call(module.exports.getTemplateListInfos );
+    },
+    
+    //new functions related to devices in version 7
+    getBasicDeviceStats: function() {
+        return this.call(module.exports.getBasicDeviceStats);
     },
 
     getDeviceList: function() {
@@ -386,13 +391,32 @@ module.exports.getTemplateListInfos  = function(sid, options)
     return executeCommand(sid, 'gettemplatelistinfos', null, options);
 };
 
+// get template information (json)
+module.exports.getTemplateList = function(sid, options)
+{
+    return module.exports.getTemplateListInfos(sid, options).then(function(templateinfo) {
+        var templates = parser.xml2json(templateinfo);
+        // extract templates as array
+        templates = [].concat((templates.templatelist || {}).template || []).map(function(template) {
+            return template;
+        });
+        return templates;
+    });
+};
+
 // apply template
-module.exports.setTemplate = function(sid, ain, options)
+module.exports.applyTemplate = function(sid, ain, options)
 {
     return executeCommand(sid, 'applytemplate', ain, options).then(function(body) {
         var patt = new RegExp(ain);
         return patt.test(body); // returns applied ain if success -> true if successful
     });
+};
+
+// get basic device info (XML)
+module.exports.getBasicDeviceStats  = function(sid, options)
+{
+    return executeCommand(sid, 'getbasicdevicestats', null, options);
 };
 
 // get detailed device information (XML)

--- a/index.js
+++ b/index.js
@@ -94,7 +94,16 @@ Fritz.prototype = {
     getDeviceListInfo: function() {
         return this.call(module.exports.getDeviceListInfo);
     },
+    
+    //new functions related to templates in version 7
+    getTemplateListInfos : function() {
+        return this.call(module.exports.getTemplateListInfos );
+    },
 
+    setTemplate: function(ain) {
+        return this.call(module.exports.setTemplate, ain);
+    },
+    
     getDeviceListInfos: function() {
         return this.call(module.exports.getDeviceListInfos);
     },
@@ -368,6 +377,21 @@ module.exports.getOSVersion = function(sid, options)
             ? json.data.fritzos.nspver
             : null;
         return osVersion;
+    });
+};
+
+// get template information (XML)
+module.exports.getTemplateListInfos  = function(sid, options)
+{
+    return executeCommand(sid, 'gettemplatelistinfos', null, options);
+};
+
+// apply template
+module.exports.setTemplate = function(sid, ain, options)
+{
+    return executeCommand(sid, 'applytemplate', ain, options).then(function(body) {
+        var patt = new RegExp(ain);
+        return patt.test(body); // returns applied ain if success -> true if successful
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -410,8 +410,7 @@ module.exports.getTemplateList = function(sid, options)
 module.exports.applyTemplate = function(sid, ain, options)
 {
     return executeCommand(sid, 'applytemplate', ain, options).then(function(body) {
-        var patt = new RegExp(ain);
-        return patt.test(body); // returns applied ain if success -> true if successful
+        return body; // returns applied id if success
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -95,19 +95,21 @@ Fritz.prototype = {
         return this.call(module.exports.getDeviceListInfo);
     },
     
+    getDeviceListInfos: function() {
+        return this.call(module.exports.getDeviceListInfos);
+    },
+    
     //new functions related to templates in version 7
     getTemplateListInfos : function() {
-        return this.call(module.exports.getTemplateListInfos );
+        return this.call(module.exports.getTemplateListInfos);
+    },
+    getTemplateList : function() {
+        return this.call(module.exports.getTemplateList);
     },
     applyTemplate: function(ain) {
         return this.call(module.exports.applyTemplate, ain);
     },
-    
-    //new functions related to templates in version 7
-    getTemplateListInfos : function() {
-        return this.call(module.exports.getTemplateListInfos );
-    },
-    
+
     //new functions related to devices in version 7
     getBasicDeviceStats: function() {
         return this.call(module.exports.getBasicDeviceStats);

--- a/index.js
+++ b/index.js
@@ -418,7 +418,7 @@ module.exports.applyTemplate = function(sid, ain, options)
 // get basic device info (XML)
 module.exports.getBasicDeviceStats  = function(sid, options)
 {
-    return executeCommand(sid, 'getbasicdevicestats', null, options);
+    return executeCommand(sid, 'getbasicdevicestats', ain, options);
 };
 
 // get detailed device information (XML)


### PR DESCRIPTION
der Aufruf von applytemplate bring nicht die ain zurück, sondern die id.
habe den entsprechenden Aufruf wie folgt geändert:

module.exports.applyTemplate = function(sid, ain, options)
{
    return executeCommand(sid, 'applytemplate', ain, options).then(function(body) {
        **return body; // returns applied id if success**
    });
};

ich hab bloß keine Ahnung warum github den letzten PR noch mit als Delta deklariert
