### PR TITLE
Fixing using of fritz.box and not using options.url inside httpRequest

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function Fritz(username, password, uri) {
     this.sid = null;
     this.username = username;
     this.password = password;
+
     this.options = { url: uri || 'http://fritz.box' };
 
     //bitfunctions hidden, unchangable to prototype
@@ -210,13 +211,6 @@ Fritz.prototype = {
     temp2api: module.exports.temp2api
 };
 
-
-/*
- * Functional API
- */
-
-var defaults = { url: 'http://fritz.box' };
-
 /**
  * Check if numeric value
  */
@@ -230,7 +224,7 @@ function isNumeric(n) {
 function httpRequest(path, req, options)
 {
     return new Promise(function(resolve, reject) {
-        req = extend({}, defaults, req, options);
+        req = extend({}, options.url, req, options);
         req.url += path;
 
         request(req, function(error, response, body) {
@@ -331,7 +325,6 @@ module.exports.getSessionID = function(username, password, options)
 {
     if (typeof username !== 'string') throw new Error('Invalid username');
     if (typeof password !== 'string') throw new Error('Invalid password');
-
     return executeCommand(null, null, null, options, '/login_sid.lua').then(function(body) {
         var challenge = body.match("<Challenge>(.*?)</Challenge>")[1];
         var challengeResponse = challenge +'-'+


### PR DESCRIPTION
The api always used defaults in the httpRequest function so if 2 Fritz!Box exists in network only one could be accessed.

There already was the url key inside options but it was never used.