### PR TITLE
small typo (in function name) and initialization call fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Get the list of switch AINs using a customer Fritz!Box address:
 ```js
 var Fritz = require('fritzapi').Fritz;
 
-var f = new Fritz("user", "password", "192.168.178.1");
+var f = new Fritz("user", "password", "http://192.168.178.1");
 
 f.getSwitchList().then(function(ains){
   console.log(f.getSID());

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Home automation node API for Fritz!Box, Fritz!DECT and FRITZ!Powerline devices.
 
 ### General functions
 
-- Get the Fritz!OS version `getOSVserion`
+- Get the Fritz!OS version `getOSVersion`
 - Get the session ID `getSessionID`
 - Get device list as XML `getDeviceListInfos` >Fritz!OS 6.10
 - Get device list `getDeviceList` >Fritz!OS 6.10


### PR DESCRIPTION
small (but not unimportant) typo corrected din function name